### PR TITLE
remove trailing whitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Each stack should be more or less:
 ## Cannot run null_resources via SSH after first ansible run
 Ansible configures and secures our SSH configuration, so root cannot SSH anymore.
 
-Change `./global-variables` and use your username and (passphrase-less) key. Do not commit this change.  
+Change `./global-variables` and use your username and (passphrase-less) key. Do not commit this change. 
 
 
 

--- a/melong/output.tf
+++ b/melong/output.tf
@@ -5,4 +5,4 @@ output "backup_access_key_id" {
 
 output "backup_access_key_secret" {
   value = "${module.single-machine.user_access_key_secret}"
-} 
+}

--- a/menji/output.tf
+++ b/menji/output.tf
@@ -5,4 +5,4 @@ output "backup_access_key_id" {
 
 output "backup_access_key_secret" {
   value = "${module.single-machine.user_access_key_secret}"
-} 
+}


### PR DESCRIPTION
Used ` find . -type f  ! -path ./.git/* ! -path ./conf/provisioning/* -exec perl -p -i -e "s/[ \t]$//g" {} \;` to remove trailing whitespace.
